### PR TITLE
String specs

### DIFF
--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringMatchingCaseSensitiveRegex.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringMatchingCaseSensitiveRegex.st
@@ -1,0 +1,7 @@
+tests
+testStringMatchingCaseSensitiveRegex
+	| spec |
+	spec := String matchingCaseSensitiveRegex: 'test'.
+	self assert: spec class = SpecOfStringRegex.
+	self assert: spec requiredValue = 'test'.
+	self assert: spec caseSensitive

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringMatchingRegex.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringMatchingRegex.st
@@ -1,0 +1,6 @@
+tests
+testStringMatchingRegex
+	| spec |
+	spec := String matchingRegex: 'test'.
+	self assert: spec class = SpecOfStringRegex.
+	self assert: spec requiredValue = 'test'

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithBeginning.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithBeginning.st
@@ -1,0 +1,6 @@
+tests
+testStringWithBeginning
+	| spec |
+	spec := String withBeginning: 'test'.
+	self assert: spec class = SpecOfStringBeginning.
+	self assert: spec requiredValue = 'test'

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithCaseSensitiveBeginning.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithCaseSensitiveBeginning.st
@@ -1,0 +1,7 @@
+tests
+testStringWithCaseSensitiveBeginning
+	| spec |
+	spec := String withCaseSensitiveBeginning: 'test'.
+	self assert: spec class = SpecOfStringBeginning.
+	self assert: spec requiredValue = 'test'.
+	self assert: spec caseSensitive

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithCaseSensitiveEnding.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithCaseSensitiveEnding.st
@@ -1,0 +1,7 @@
+tests
+testStringWithCaseSensitiveEnding
+	| spec |
+	spec := String withCaseSensitiveEnding: 'test'.
+	self assert: spec class = SpecOfStringEnding.
+	self assert: spec requiredValue = 'test'.
+	self assert: spec caseSensitive

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithCaseSensitiveSubstring.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithCaseSensitiveSubstring.st
@@ -1,0 +1,7 @@
+tests
+testStringWithCaseSensitiveSubstring
+	| spec |
+	spec := String withCaseSensitiveSubstring: 'test'.
+	self assert: spec class = SpecOfSubstring.
+	self assert: spec requiredValue = 'test'.
+	self assert: spec caseSensitive

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithEnding.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithEnding.st
@@ -1,0 +1,6 @@
+tests
+testStringWithEnding
+	| spec |
+	spec := String withEnding: 'test'.
+	self assert: spec class = SpecOfStringEnding.
+	self assert: spec requiredValue = 'test'

--- a/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithSubstring.st
+++ b/StateSpecs-DSL-ClassWords-Tests.package/SpecOfDSLClassWordsTests.class/instance/testStringWithSubstring.st
@@ -1,0 +1,6 @@
+tests
+testStringWithSubstring
+	| spec |
+	spec := String withSubstring: 'test'.
+	self assert: spec class = SpecOfSubstring.
+	self assert: spec requiredValue = 'test'

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/matchingCaseSensitiveRegex..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/matchingCaseSensitiveRegex..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+matchingCaseSensitiveRegex: requiredString
+
+	^SpecOfStringRegex requiredValue: requiredString caseSensitive: true

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/matchingRegex..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/matchingRegex..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+matchingRegex: requiredString
+
+	^SpecOfStringRegex requiredValue: requiredString

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/withBeginning..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/withBeginning..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+withBeginning: requiredString
+
+	^SpecOfStringBeginning requiredValue: requiredString

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/withCaseSensitiveBeginning..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/withCaseSensitiveBeginning..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+withCaseSensitiveBeginning: requiredString
+
+	^SpecOfStringBeginning requiredValue: requiredString caseSensitive: true

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/withCaseSensitiveEnding..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/withCaseSensitiveEnding..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+withCaseSensitiveEnding: requiredString
+
+	^SpecOfStringEnding requiredValue: requiredString caseSensitive: true

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/withCaseSensitiveSubstring..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/withCaseSensitiveSubstring..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+withCaseSensitiveSubstring: requiredString
+
+	^SpecOfSubstring requiredValue: requiredString caseSensitive: true

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/withEnding..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/withEnding..st
@@ -1,0 +1,4 @@
+*StateSpecs-DSL-ClassWords
+withEnding: requiredString
+
+	^SpecOfStringEnding requiredValue: requiredString

--- a/StateSpecs-DSL-ClassWords.package/String.extension/class/withSubstring..st
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/class/withSubstring..st
@@ -1,0 +1,5 @@
+*StateSpecs-DSL-ClassWords
+withSubstring: requiredString
+
+	^SpecOfSubstring requiredValue: requiredString
+	

--- a/StateSpecs-DSL-ClassWords.package/String.extension/properties.json
+++ b/StateSpecs-DSL-ClassWords.package/String.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "String"
+}

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringBeginsWithPrefix.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringBeginsWithPrefix.st
@@ -1,0 +1,5 @@
+tests
+testStringBeginsWithPrefix
+	self shouldnt: ['test string' should beginWith: 'test'] raise: SpecOfFailed.
+	self shouldnt: ['test string' should beginWith: 'Test'] raise: SpecOfFailed.
+	self should: ['some test string' should beginWith: 'test'] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringBeginsWithPrefixCaseSensitive.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringBeginsWithPrefixCaseSensitive.st
@@ -1,0 +1,5 @@
+tests
+testStringBeginsWithPrefixCaseSensitive
+	self shouldnt: ['test string' should beginWith: 'test' caseSensitive: true] raise: SpecOfFailed.
+	self should: ['test string' should beginWith: 'Test' caseSensitive: true] raise: SpecOfFailed.
+	self should: ['some test string' should beginWith: 'test' caseSensitive: true] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringEndsWithSuffix.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringEndsWithSuffix.st
@@ -1,0 +1,5 @@
+tests
+testStringEndsWithSuffix
+	self shouldnt: ['string test' should endWith: 'test'] raise: SpecOfFailed.
+	self shouldnt: ['string test' should endWith: 'Test'] raise: SpecOfFailed.
+	self should: ['some test string' should endWith: 'test'] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringEndsWithSuffixCaseSensitive.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringEndsWithSuffixCaseSensitive.st
@@ -1,0 +1,5 @@
+tests
+testStringEndsWithSuffixCaseSensitive
+	self shouldnt: ['string test' should endWith: 'test' caseSensitive: true] raise: SpecOfFailed.
+	self should: ['string test' should endWith: 'Test' caseSensitive: true] raise: SpecOfFailed.
+	self should: ['some test string' should endWith: 'test' caseSensitive: true] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringIncludesSubstring.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringIncludesSubstring.st
@@ -1,0 +1,5 @@
+tests
+testStringIncludesSubstring
+	self shouldnt: ['some test string' should includeSubstring: 'test'] raise: SpecOfFailed.
+	self shouldnt: ['some test string' should includeSubstring: 'Test'] raise: SpecOfFailed.
+	self should: ['some string' should includeSubstring: 'test'] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringIncludesSubstringCaseSensitive.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringIncludesSubstringCaseSensitive.st
@@ -1,0 +1,8 @@
+tests
+testStringIncludesSubstringCaseSensitive
+	self shouldnt: [
+		'some test string' should includeSubstring: 'test' caseSensitive: true] raise: SpecOfFailed.
+	self should: [
+		'some test string' should includeSubstring: 'Test'  caseSensitive: true] raise: SpecOfFailed.
+	self should: [
+		'some string' should includeSubstring: 'test' caseSensitive: true] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringMatchesWithRegex.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringMatchesWithRegex.st
@@ -1,0 +1,5 @@
+tests
+testStringMatchesWithRegex
+	self shouldnt: ['test string' should matchRegex: '^test'] raise: SpecOfFailed.
+	self shouldnt: ['test string' should matchRegex: '^Test'] raise: SpecOfFailed.
+	self should: ['some test string' should matchRegex: '^test'] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringMatchesWithRegexCaseSensitive.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testStringMatchesWithRegexCaseSensitive.st
@@ -1,0 +1,5 @@
+tests
+testStringMatchesWithRegexCaseSensitive
+	self shouldnt: ['test string' should matchRegex: '^test' caseSensitive: true] raise: SpecOfFailed.
+	self should: ['test string' should matchRegex: '^Test' caseSensitive: true] raise: SpecOfFailed.
+	self should: ['some test string' should matchRegex: '^test' caseSensitive: true] raise: SpecOfFailed

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/be..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/be..st
@@ -1,3 +1,3 @@
 expressions
 be: anObject 
-	^self verify: (SpecOfIdentity to: anObject)
+	^self verify: (SpecOfIdentity requiredValue: anObject)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/be.description..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/be.description..st
@@ -1,7 +1,7 @@
 expressions
 be: anObject description: failureDescription
 	| spec |
-	spec := (SpecOfIdentity to: anObject).
+	spec := (SpecOfIdentity requiredValue: anObject).
 	spec failureDescription: failureDescription.
 	
 	^self verify: spec

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/beginWith..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/beginWith..st
@@ -1,0 +1,3 @@
+expressions
+beginWith: aString
+	^ self verify: (SpecOfStringBeginning requiredValue: aString)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/beginWith.caseSensitive..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/beginWith.caseSensitive..st
@@ -1,0 +1,3 @@
+expressions
+beginWith: aString caseSensitive: aBool
+	^ self verify: (SpecOfStringBeginning requiredValue: aString caseSensitive: aBool)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/endWith..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/endWith..st
@@ -1,0 +1,3 @@
+expressions
+endWith: aString
+	^ self verify: (SpecOfStringEnding requiredValue: aString)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/endWith.caseSensitive..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/endWith.caseSensitive..st
@@ -1,0 +1,3 @@
+expressions
+endWith: aString caseSensitive: aBool
+	^ self verify: (SpecOfStringEnding requiredValue: aString caseSensitive: aBool)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/equal..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/equal..st
@@ -1,3 +1,3 @@
 expressions
 equal: anObject 
-	^self verify: (SpecOfEquality to: anObject)
+	^self verify: (SpecOfEquality requiredValue: anObject)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/equal.description..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/equal.description..st
@@ -1,7 +1,7 @@
 expressions
 equal: anObject description: failureDescription
 	| spec |
-	spec := (SpecOfEquality to: anObject) .
+	spec := (SpecOfEquality requiredValue: anObject) .
 	spec failureDescription: failureDescription.
 	
 	^self verify: spec

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/equalInOrder..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/equalInOrder..st
@@ -1,3 +1,3 @@
 expressions
 equalInOrder: anObject 
-	^self verify: (SpecOfCollectionOrderedEquality to: anObject)
+	^self verify: (SpecOfCollectionOrderedEquality requiredValue: anObject)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/includeSubstring..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/includeSubstring..st
@@ -1,0 +1,3 @@
+expressions
+includeSubstring: aString
+	^ self verify: (SpecOfSubstring requiredValue: aString)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/includeSubstring.caseSensitive..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/includeSubstring.caseSensitive..st
@@ -1,0 +1,3 @@
+expressions
+includeSubstring: aString caseSensitive: aBool
+	^ self verify: (SpecOfSubstring requiredValue: aString caseSensitive: aBool)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/matchRegex..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/matchRegex..st
@@ -1,0 +1,3 @@
+expressions
+matchRegex: aRegexString
+	^ self verify: (SpecOfStringRegex requiredValue: aRegexString)

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/matchRegex.caseSensitive..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/matchRegex.caseSensitive..st
@@ -1,0 +1,3 @@
+expressions
+matchRegex: aRegexString caseSensitive: aBool
+	^ self verify: (SpecOfStringRegex requiredValue: aRegexString caseSensitive: aBool)

--- a/StateSpecs-GTTools.package/SpecOfString.extension/instance/gtInspectorIn.forFailedValidationOf..st
+++ b/StateSpecs-GTTools.package/SpecOfString.extension/instance/gtInspectorIn.forFailedValidationOf..st
@@ -1,0 +1,7 @@
+*StateSpecs-GTTools
+gtInspectorIn: composite forFailedValidationOf: anObject
+
+	^composite diff
+		title: 'String vs expected part';
+		display: [ 
+			{anObject gtDebuggerSUnitPrint. requiredValue gtDebuggerSUnitPrint} ]

--- a/StateSpecs-GTTools.package/SpecOfString.extension/properties.json
+++ b/StateSpecs-GTTools.package/SpecOfString.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "SpecOfString"
+}

--- a/StateSpecs-Help.package/StateSpecsHelp.class/class/shouldExpressions.st
+++ b/StateSpecs-Help.package/StateSpecsHelp.class/class/shouldExpressions.st
@@ -30,6 +30,15 @@ shouldExpressions
 #(1 2) should include: (Kind of: String) at: 2.
 #(1 2) should include: [:number | number > 10] at: 2.
 
+''some test string'' should includeSubstring: ''test2''
+''some test string'' should includeSubstring: ''Test'' caseSensitive: true
+''test string'' should beginWith: ''test''
+''test string'' should beginWith: ''Test'' caseSensitive: true
+''string for test'' should endWith: ''test2''
+''string for test'' should endWith: ''Test'' caseSensitive: true
+''test string'' should matchRegex: ''^test''
+''test string'' should matchRegex: ''^Test'' caseSensitive: true
+
 [1 + 2] should raise: ZeroDivide.
 [1/0] should not raise: ZeroDivide.
 [1/0] should raise: Error.

--- a/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testMatches.st
@@ -1,7 +1,7 @@
 tests
 testMatches
 	| spec1 spec2 stateSpec |
-	spec1 := SpecOfEquality to: #expectedValue.
+	spec1 := SpecOfEquality requiredValue: #expectedValue.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfAndConjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testValidateFailed.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testValidateFailed.st
@@ -1,7 +1,7 @@
 tests
 testValidateFailed
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: #expectedValue.
+	spec1 := SpecOfEquality requiredValue: #expectedValue.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfAndConjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testValidateFailed2.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testValidateFailed2.st
@@ -1,7 +1,7 @@
 tests
 testValidateFailed2
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfAndConjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testValidateSuccessful.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfAndConjunctionTests.class/instance/testValidateSuccessful.st
@@ -1,7 +1,7 @@
 tests
 testValidateSuccessful
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: #expectedValue.
+	spec1 := SpecOfEquality requiredValue: #expectedValue.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfAndConjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testFailedValidationWithExplicitFailureSpec.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testFailedValidationWithExplicitFailureSpec.st
@@ -3,7 +3,7 @@ testFailedValidationWithExplicitFailureSpec
 	| spec result expectedError anotherError |
 	expectedError := Error new messageText: 'test error'.
 	
-	spec := SpecOfBlockFailure requiredFailure: (SpecOfIdentity to: expectedError).	
+	spec := SpecOfBlockFailure requiredFailure: (SpecOfIdentity requiredValue: expectedError).	
 	
 	anotherError := Error new messageText: 'another error'.
 	

--- a/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testSucceedValidationWithExplicitFailureSpec.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testSucceedValidationWithExplicitFailureSpec.st
@@ -3,7 +3,7 @@ testSucceedValidationWithExplicitFailureSpec
 	| spec result expectedError |
 	expectedError := Error new messageText: 'test error'.
 	
-	spec := SpecOfBlockFailure requiredFailure: (SpecOfIdentity to: expectedError).	
+	spec := SpecOfBlockFailure requiredFailure: (SpecOfIdentity requiredValue: expectedError).	
 	
 	result := spec validate: [ expectedError signal].
 	

--- a/StateSpecs-Specs-Tests.package/SpecOfComplexStateTests.class/instance/testCreation.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfComplexStateTests.class/instance/testCreation.st
@@ -2,7 +2,7 @@ tests
 testCreation
 	
 	| spec1 complexSpec |
-	spec1 := SpecOfEquality to: 1.
+	spec1 := SpecOfEquality requiredValue: 1.
 	
 	complexSpec := SpecOfComplexState of: spec1 and: 3.
 

--- a/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testMatches.st
@@ -1,7 +1,7 @@
 tests
 testMatches
 	| spec1 spec2 stateSpec |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfNegation of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testValidateFailed.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testValidateFailed.st
@@ -1,7 +1,7 @@
 tests
 testValidateFailed
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfNegation of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testValidateFailed2.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testValidateFailed2.st
@@ -1,7 +1,7 @@
 tests
 testValidateFailed2
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfNegation of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testValidateSuccessful.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfNegationTests.class/instance/testValidateSuccessful.st
@@ -1,7 +1,7 @@
 tests
 testValidateSuccessful
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfNegation of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testMatches.st
@@ -1,7 +1,7 @@
 tests
 testMatches
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfOrDisjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testValidateFailed.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testValidateFailed.st
@@ -1,7 +1,7 @@
 tests
 testValidateFailed
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfOrDisjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testValidateSuccessful.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testValidateSuccessful.st
@@ -1,7 +1,7 @@
 tests
 testValidateSuccessful
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfOrDisjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testValidateSuccessful2.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfOrDisjunctionTests.class/instance/testValidateSuccessful2.st
@@ -1,7 +1,7 @@
 tests
 testValidateSuccessful2
 	| spec1 spec2 stateSpec result |
-	spec1 := SpecOfEquality to: 2.
+	spec1 := SpecOfEquality requiredValue: 2.
 	spec2 := SpecOfObjectSuperclass requiredClass: String.
 	
 	stateSpec := SpecOfOrDisjunction of: spec1 and: spec2.

--- a/StateSpecs-Specs-Tests.package/SpecOfStringBeginningTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringBeginningTests.class/instance/testMatches.st
@@ -1,0 +1,8 @@
+tests
+testMatches
+	| spec |
+	spec := SpecOfStringBeginning requiredValue: 'test'.
+	
+	self assert: (spec matches: 'test string').
+	self assert: (spec matches: 'Test string').
+	self deny: (spec matches: 'some test string')

--- a/StateSpecs-Specs-Tests.package/SpecOfStringBeginningTests.class/instance/testMatchesCaseSensitive.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringBeginningTests.class/instance/testMatchesCaseSensitive.st
@@ -1,0 +1,8 @@
+tests
+testMatchesCaseSensitive
+	| spec |
+	spec := SpecOfStringBeginning requiredValue: 'test' caseSensitive: true.
+	
+	self assert: (spec matches: 'test string').
+	self deny: (spec matches: 'Test string').
+	self deny: (spec matches: 'some test string')

--- a/StateSpecs-Specs-Tests.package/SpecOfStringBeginningTests.class/properties.json
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringBeginningTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "StateSpecs-Specs-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfStringBeginningTests",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs-Tests.package/SpecOfStringEndingTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringEndingTests.class/instance/testMatches.st
@@ -1,0 +1,8 @@
+tests
+testMatches
+	| spec |
+	spec := SpecOfStringEnding requiredValue: 'test'.
+	
+	self assert: (spec matches: 'string for test').
+	self assert: (spec matches: 'string for Test').
+	self deny: (spec matches: 'some test string')

--- a/StateSpecs-Specs-Tests.package/SpecOfStringEndingTests.class/instance/testMatchesCaseSensitive.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringEndingTests.class/instance/testMatchesCaseSensitive.st
@@ -1,0 +1,8 @@
+tests
+testMatchesCaseSensitive
+	| spec |
+	spec := SpecOfStringEnding requiredValue: 'test' caseSensitive: true.
+	
+	self assert: (spec matches: 'string for test').
+	self deny: (spec matches: 'string for Test').
+	self deny: (spec matches: 'some test string')

--- a/StateSpecs-Specs-Tests.package/SpecOfStringEndingTests.class/properties.json
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringEndingTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "StateSpecs-Specs-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfStringEndingTests",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs-Tests.package/SpecOfStringRegexTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringRegexTests.class/instance/testMatches.st
@@ -1,0 +1,8 @@
+tests
+testMatches
+	| spec |
+	spec := SpecOfStringRegex requiredValue: '^test'.
+	
+	self assert: (spec matches: 'test string').
+	self assert: (spec matches: 'Test string').
+	self deny: (spec matches: 'some test string')

--- a/StateSpecs-Specs-Tests.package/SpecOfStringRegexTests.class/instance/testMatchesCaseSensitive.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringRegexTests.class/instance/testMatchesCaseSensitive.st
@@ -1,0 +1,8 @@
+tests
+testMatchesCaseSensitive
+	| spec |
+	spec := SpecOfStringRegex requiredValue: '^test' caseSensitive: true.
+	
+	self assert: (spec matches: 'test string').
+	self deny: (spec matches: 'Test string').
+	self deny: (spec matches: 'some test string')

--- a/StateSpecs-Specs-Tests.package/SpecOfStringRegexTests.class/properties.json
+++ b/StateSpecs-Specs-Tests.package/SpecOfStringRegexTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "StateSpecs-Specs-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfStringRegexTests",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs-Tests.package/SpecOfSubstringTests.class/instance/testMatches.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfSubstringTests.class/instance/testMatches.st
@@ -1,0 +1,8 @@
+tests
+testMatches
+	| spec |
+	spec := SpecOfSubstring requiredValue: 'test'.
+	
+	self assert: (spec matches: 'some test string').
+	self assert: (spec matches: 'some Test string').
+	self deny: (spec matches: 'some string')

--- a/StateSpecs-Specs-Tests.package/SpecOfSubstringTests.class/instance/testMatchesCaseSensitive.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfSubstringTests.class/instance/testMatchesCaseSensitive.st
@@ -1,0 +1,8 @@
+tests
+testMatchesCaseSensitive
+	| spec |
+	spec := SpecOfSubstring requiredValue: 'test' caseSensitive: true.
+	
+	self assert: (spec matches: 'some test string').
+	self deny: (spec matches: 'some Test string').
+	self deny: (spec matches: 'some string')

--- a/StateSpecs-Specs-Tests.package/SpecOfSubstringTests.class/properties.json
+++ b/StateSpecs-Specs-Tests.package/SpecOfSubstringTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "StateSpecs-Specs-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfSubstringTests",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs.package/SpecOfComplexState.class/instance/copy.st
+++ b/StateSpecs-Specs.package/SpecOfComplexState.class/instance/copy.st
@@ -1,4 +1,4 @@
-accessing
+copying
 copy
 	| result |
 	result := super copy.

--- a/StateSpecs-Specs.package/SpecOfIdentity.class/class/to..st
+++ b/StateSpecs-Specs.package/SpecOfIdentity.class/class/to..st
@@ -1,0 +1,3 @@
+accessing
+to: requiredValue
+	^self requiredValue: requiredValue

--- a/StateSpecs-Specs.package/SpecOfObjectValue.class/class/to..st
+++ b/StateSpecs-Specs.package/SpecOfObjectValue.class/class/to..st
@@ -1,3 +1,0 @@
-instance creation
-to: anObject 
-	^self requiredValue: anObject

--- a/StateSpecs-Specs.package/SpecOfString.class/README.md
+++ b/StateSpecs-Specs.package/SpecOfString.class/README.md
@@ -1,0 +1,16 @@
+I am root of hierarchy of string specifications.
+
+I provide requiredSubstring and caseSensitive properties. And my subclasses should use them accordingly their logic. 
+
+Instance should be created using following messages: 
+
+	SpecOfString requiredSubstring: 'test'.
+	SpecOfString requiredSubstring: 'test' caseSensitive: false
+
+My default I am not case sensitive.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	caseSensitive:		<Boolean>
+	requiredSubstring:		<String>

--- a/StateSpecs-Specs.package/SpecOfString.class/class/requiredValue.caseSensitive..st
+++ b/StateSpecs-Specs.package/SpecOfString.class/class/requiredValue.caseSensitive..st
@@ -1,0 +1,5 @@
+instance creation
+requiredValue: aString caseSensitive: aBool
+
+	^(self requiredValue: aString)
+		caseSensitive: aBool

--- a/StateSpecs-Specs.package/SpecOfString.class/instance/caseSensitive..st
+++ b/StateSpecs-Specs.package/SpecOfString.class/instance/caseSensitive..st
@@ -1,0 +1,3 @@
+accessing
+caseSensitive: anObject
+	caseSensitive := anObject

--- a/StateSpecs-Specs.package/SpecOfString.class/instance/caseSensitive.st
+++ b/StateSpecs-Specs.package/SpecOfString.class/instance/caseSensitive.st
@@ -1,0 +1,3 @@
+accessing
+caseSensitive
+	^ caseSensitive

--- a/StateSpecs-Specs.package/SpecOfString.class/instance/defaultTitle.st
+++ b/StateSpecs-Specs.package/SpecOfString.class/instance/defaultTitle.st
@@ -1,0 +1,6 @@
+accessing
+defaultTitle
+
+	^caseSensitive
+		ifFalse: [ super defaultTitle ]
+		ifTrue: [ super defaultTitle , ' case sensitive' ] 

--- a/StateSpecs-Specs.package/SpecOfString.class/instance/initialize.st
+++ b/StateSpecs-Specs.package/SpecOfString.class/instance/initialize.st
@@ -1,0 +1,5 @@
+initialize-release
+initialize
+	super initialize.
+	
+	caseSensitive := false

--- a/StateSpecs-Specs.package/SpecOfString.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfString.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "DenisKudryashov 2/28/2018 11:49",
+	"super" : "SpecOfObjectValue",
+	"category" : "StateSpecs-Specs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"caseSensitive"
+	],
+	"name" : "SpecOfString",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs.package/SpecOfStringBeginning.class/instance/basicMatches..st
+++ b/StateSpecs-Specs.package/SpecOfStringBeginning.class/instance/basicMatches..st
@@ -1,0 +1,6 @@
+testing
+basicMatches: aString
+	
+	^caseSensitive 
+		ifTrue: [ aString beginsWith: requiredValue]
+		ifFalse: [ aString asLowercase beginsWith: requiredValue asLowercase ]

--- a/StateSpecs-Specs.package/SpecOfStringBeginning.class/instance/clauseKeyword.st
+++ b/StateSpecs-Specs.package/SpecOfStringBeginning.class/instance/clauseKeyword.st
@@ -1,0 +1,3 @@
+displaying
+clauseKeyword
+	^'begin with'

--- a/StateSpecs-Specs.package/SpecOfStringBeginning.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfStringBeginning.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "SpecOfString",
+	"category" : "StateSpecs-Specs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfStringBeginning",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs.package/SpecOfStringEnding.class/instance/basicMatches..st
+++ b/StateSpecs-Specs.package/SpecOfStringEnding.class/instance/basicMatches..st
@@ -1,0 +1,6 @@
+testing
+basicMatches: aString
+	
+	^caseSensitive 
+		ifTrue: [ aString endsWith: requiredValue]
+		ifFalse: [ aString asLowercase endsWith: requiredValue asLowercase ]

--- a/StateSpecs-Specs.package/SpecOfStringEnding.class/instance/clauseKeyword.st
+++ b/StateSpecs-Specs.package/SpecOfStringEnding.class/instance/clauseKeyword.st
@@ -1,0 +1,3 @@
+displaying
+clauseKeyword
+	^'end with'

--- a/StateSpecs-Specs.package/SpecOfStringEnding.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfStringEnding.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "SpecOfString",
+	"category" : "StateSpecs-Specs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfStringEnding",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs.package/SpecOfStringRegex.class/instance/basicMatches..st
+++ b/StateSpecs-Specs.package/SpecOfStringRegex.class/instance/basicMatches..st
@@ -1,0 +1,6 @@
+testing
+basicMatches: aString
+	
+	^caseSensitive 
+		ifTrue: [ requiredValue asRegex search: aString]
+		ifFalse: [ requiredValue asRegexIgnoringCase search: aString]

--- a/StateSpecs-Specs.package/SpecOfStringRegex.class/instance/clauseKeyword.st
+++ b/StateSpecs-Specs.package/SpecOfStringRegex.class/instance/clauseKeyword.st
@@ -1,0 +1,3 @@
+displaying
+clauseKeyword
+	^'match regex'

--- a/StateSpecs-Specs.package/SpecOfStringRegex.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfStringRegex.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "SpecOfString",
+	"category" : "StateSpecs-Specs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfStringRegex",
+	"type" : "normal"
+}

--- a/StateSpecs-Specs.package/SpecOfSubstring.class/instance/basicMatches..st
+++ b/StateSpecs-Specs.package/SpecOfSubstring.class/instance/basicMatches..st
@@ -1,0 +1,3 @@
+testing
+basicMatches: aString
+	^aString includesSubstring: requiredValue caseSensitive: caseSensitive 

--- a/StateSpecs-Specs.package/SpecOfSubstring.class/instance/clauseKeyword.st
+++ b/StateSpecs-Specs.package/SpecOfSubstring.class/instance/clauseKeyword.st
@@ -1,0 +1,3 @@
+displaying
+clauseKeyword
+	^'include substring'

--- a/StateSpecs-Specs.package/SpecOfSubstring.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfSubstring.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "SpecOfString",
+	"category" : "StateSpecs-Specs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SpecOfSubstring",
+	"type" : "normal"
+}


### PR DESCRIPTION
New String specs are implemented:
- SpecOfSubstring
'some test string' should includeSubstring: 'test'
'some test string' should includeSubstring: 'test' caseSensitive: true
 String withSubstring: 'test'
- SpecOfStringBeginning
'test string' should beginWith: 'test'
'test string' should beginWith: 'test' caseSensitive: true
 String withBeginning: 'test'
- SpecOfStringEnding
'string for test' should endWith: 'test'
'string for test' should endWith: 'test' caseSensitive: true
String withEnding: 'test'
- SpecOfStringRegex
'test string' should matchRegex: '^test'
'test string' should matchRegex: '^test' caseSensitive: true
 String matchingRegex: '^test'