### PR TITLE
New release: better failure validation logic

### DIFF
--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testRaisingExeption.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testRaisingExeption.st
@@ -1,9 +1,16 @@
 tests
 testRaisingExeption
 	self shouldnt: [[1 / 0] should raise: ZeroDivide] raise: SpecOfFailed.
-	self should: [[1 / 0] should raise: Error] raise: SpecOfFailed.
+	self shouldnt: [[1 / 0] should raise: Error] raise: SpecOfFailed.
+	self should: [[1 / 0] should raise: (Instance of: Error)] raise: SpecOfFailed.
 	self should: [[1 / 3] should raise: ZeroDivide] raise: SpecOfFailed.
+	
 	self shouldnt: [[1 / 0] should fail] raise: SpecOfFailed. 
+	self shouldnt: [ | error |
+		error := [self error: 'you can validate signaled error after should'] should fail.
+		error should beInstanceOf: Error.
+		error where description should includeSubstring: 'can validate'] raise: SpecOfFailed.
+	
 	self should: [[1 / 3] should fail] raise: SpecOfFailed.
 	self shouldnt: [[1 / 1] should not raise: ZeroDivide] raise: SpecOfFailed.
 	self should: [[1 / 0] should not raise: ZeroDivide] raise: SpecOfFailed.

--- a/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testReturningValidationResults.st
+++ b/StateSpecs-DSL-ShouldExpressions-Tests.package/SpecOfShouldExpressionTests.class/instance/testReturningValidationResults.st
@@ -12,8 +12,8 @@ testReturningValidationResults
 	] on: SpecOfFailed do: #resume.
 
 	results size should be: 5.
-	(results at: 1) should be isSuccess.
-	(results at: 2) should be isFailure.
-	(results at: 3) should be isSuccess.
-	(results at: 4) should be isSuccess.
-	(results at: 5) should be isSuccess
+	self assert: (results at: 1) isSuccess.
+	self assert: (results at: 2) isFailure.
+	self assert: (results at: 3) isSuccess.
+	self assert: (results at: 4) isSuccess.
+	self assert: (results at: 5) isSuccess

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/fail.st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/fail.st
@@ -1,3 +1,3 @@
 expressions
 fail
-	^self raise: (SpecOfObjectSuperclass requiredClass: Error)
+	^self raise: Error

--- a/StateSpecs-Help.package/StateSpecsHelp.class/class/shouldExpressions.st
+++ b/StateSpecs-Help.package/StateSpecsHelp.class/class/shouldExpressions.st
@@ -42,10 +42,12 @@ shouldExpressions
 [1 + 2] should raise: ZeroDivide.
 [1/0] should not raise: ZeroDivide.
 [1/0] should raise: Error.
-[1/0] should raise: (Kind of: Error).
+[1/0] should raise: (Instance of: Error).
 [1/0] should fail.
 [self error: ''test''] should raise: errorInstance. "fail because raised error is not the same as expected errorInstance"
 [1 + 2] should not fail.
+error := [ self error: ''test cool error'' ] should fail.
+error description should includeSubstring: ''cool''
 
 3 should be even.
 2 should not be even.

--- a/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testSucceedValidationShouldKeepSignaledFailure.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testSucceedValidationShouldKeepSignaledFailure.st
@@ -1,0 +1,11 @@
+tests
+testSucceedValidationShouldKeepSignaledFailure
+	| spec result expectedError |
+	expectedError := Error new messageText: 'test error'.
+	
+	spec := SpecOfBlockFailure requiredFailure: Any.	
+	
+	result := spec validate: [ expectedError signal].
+	
+	self assert: result isSuccess.
+	self assert: result signaledFailure == expectedError

--- a/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testValidationOfBlockFailedByAnotherError.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testValidationOfBlockFailedByAnotherError.st
@@ -7,5 +7,4 @@ testValidationOfBlockFailedByAnotherError
 	result := spec validate: [ error signal].
 	
 	self assert: result isFailure.
-	self assert: result description equals: 'Got "', error stringForSpecValidation ,'" but it should be an instance of ZeroDivide'.
-	
+	self assert: result description equals: 'Got "', error stringForSpecValidation ,'" but it should be a kind of ZeroDivide'

--- a/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testValidationOfNotFailedBlock.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfBlockFailureTests.class/instance/testValidationOfNotFailedBlock.st
@@ -6,4 +6,4 @@ testValidationOfNotFailedBlock
 	result := spec validate: [ 'blockBody' ].
 	
 	self assert: result isFailure.
-	self assert: result description equals: 'Got no failures but should be an instance of ZeroDivide'
+	self assert: result description equals: 'Got no failures but should be a kind of ZeroDivide'

--- a/StateSpecs-Specs.package/Interval.extension/instance/checkStateSpecsOrderedEqualityTo..st
+++ b/StateSpecs-Specs.package/Interval.extension/instance/checkStateSpecsOrderedEqualityTo..st
@@ -1,4 +1,4 @@
 *StateSpecs-Specs
 checkStateSpecsOrderedEqualityTo: anotherCollection
 
-	^self checkStateSpecsOrderedEqualityTo: anotherCollection
+	^self checkStateSpecsEqualityTo: anotherCollection

--- a/StateSpecs-Specs.package/SpecOfBlockFailure.class/README.md
+++ b/StateSpecs-Specs.package/SpecOfBlockFailure.class/README.md
@@ -17,7 +17,7 @@ By default I implement special logic to catch unexpected exceptions and return i
 This code will not show debugger at point of SubscriptOutOfBounds error.  But it will show that specification is failed and SubscriptOutOfBounds was thrown instead of ZeroDivide. Pressing proceed in debugger will move it to original failure. 
 
 To disable this behaviour I have variable shouldPassUnexpectedFailure.
-Also I have array of special failures which should be always passed without validation logic. It is Halt, MessageNotUnderstood and SpecOfFailed. Usually this errorrs should be thrown immediatly in debugger. 
+Also I have array of special failures which should be always passed without validation logic. It is Halt, MessageNotUnderstood and SpecOfFailed. Usually this errors should be thrown immediatly in debugger. 
 
 	[ 1 someMessage ] should raise: Error
 
@@ -26,8 +26,18 @@ But if errors are explicitly expected failures then they will be checked by vali
 
 	[ 1 someMessage ] should raise: MessageNotUnderstood 
 
-This code will not openes debugger because validation is succeed.
+This code will not open debugger because validation is succeed.
 
+In addition I return special success validation result (SpecOfFailureValidationSuccess) which holds signaled exception instance: 
+
+	errorValidation := [ self error: 'my test error' ] should fail.
+	errorValidation signaledFailure "==> Error: my test error"
+
+It allows to perform additional validation over caught failure: 
+
+	errorValidation should beInstanceOf: Error.
+	errorValidation where description should includesSubstring: 'my test'.
+	
 Internal Representation and Key Implementation Points.
 
     Instance Variables

--- a/StateSpecs-Specs.package/SpecOfBlockFailure.class/instance/specForFailure..st
+++ b/StateSpecs-Specs.package/SpecOfBlockFailure.class/instance/specForFailure..st
@@ -2,5 +2,5 @@ accessing
 specForFailure: exceptionClassOrSpec
 
 	^exceptionClassOrSpec isClass & (exceptionClassOrSpec ~= Any)
-		ifTrue: [ SpecOfObjectClass requiredClass: exceptionClassOrSpec ]
+		ifTrue: [ SpecOfObjectSuperclass requiredClass: exceptionClassOrSpec ]
 		ifFalse: [ exceptionClassOrSpec asStateSpec ]

--- a/StateSpecs-Specs.package/SpecOfBlockFailure.class/instance/validate..st
+++ b/StateSpecs-Specs.package/SpecOfBlockFailure.class/instance/validate..st
@@ -13,7 +13,7 @@ validate: aBlock
 				result := requiredFailure validate: ex.
 			
 				result isSuccess 
-					ifTrue: [ result ] 
+					ifTrue: [ SpecOfFailureValidationSuccess with: ex ] 
 					ifFalse: [ 
 						shouldPassUnexpectedFailures
 							ifTrue: [ ex pass ]

--- a/StateSpecs-Specs.package/SpecOfBlockFailure.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfBlockFailure.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "DenisKudryashov 3/2/2016 16:55",
+	"commentStamp" : "DenisKudriashov 3/19/2019 22:05",
 	"super" : "SpecOfObjectState",
 	"category" : "StateSpecs-Specs",
 	"classinstvars" : [ ],

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/README.md
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/README.md
@@ -1,0 +1,16 @@
+I represent successful result of failure validation during block execution by SpecOfBlockFailure spec.
+
+I was introduced to not loose caught exception instance and allow extra validation using should expressions: 
+
+	error := [ self error: 'some error' ] should raise: Error.
+	error should beInstanceOf: Error.
+	error where description should includeSubstring: 'some'
+
+Create my instances with following expression: 
+
+	SpecOfFailureValidationSuccess with: anError
+	
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	signaledFailure:		<Exception>

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/class/with..st
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/class/with..st
@@ -1,0 +1,4 @@
+instance creation
+with: anException
+	^self new 
+		signaledFailure: anException

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/should.st
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/should.st
@@ -1,0 +1,3 @@
+asserting
+should
+	^signaledFailure should

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/signaledFailure..st
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/signaledFailure..st
@@ -1,0 +1,3 @@
+accessing
+signaledFailure: anObject
+	signaledFailure := anObject

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/signaledFailure.st
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/signaledFailure.st
@@ -1,0 +1,3 @@
+accessing
+signaledFailure
+	^ signaledFailure

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/where.st
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/instance/where.st
@@ -1,0 +1,3 @@
+asserting
+where
+	^signaledFailure where

--- a/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/properties.json
+++ b/StateSpecs-Specs.package/SpecOfFailureValidationSuccess.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "DenisKudriashov 3/19/2019 22:06",
+	"super" : "SpecOfValidationSuccess",
+	"category" : "StateSpecs-Specs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"signaledFailure"
+	],
+	"name" : "SpecOfFailureValidationSuccess",
+	"type" : "normal"
+}


### PR DESCRIPTION
1) Keep signaled exception instance during SpecOfBlockFailure validation:
```Smalltalk
error := [ self error: 'some error' ] should raise: Error.
error should beInstanceOf: Error.
error where description should includeSubstring: 'some'
```
2) Fix the rule "minimum restrictions by default" for failure validation:
```Smalltalk
[1 / 0] should raise: Error "is now passed"
```
If concrete error is expected it should be explicitly written using spec:
```Smalltalk
[1 / 0] should raise: (Instance of: Error) "will fail"
```