### PR TITLE
Bug fix Pharo 8

### DIFF
--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfObjectProperty.class/instance/printOn..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfObjectProperty.class/instance/printOn..st
@@ -1,4 +1,4 @@
 printing
 printOn: aStream
 
-	aStream << '"' << value << '" from ' << self stringForSpecTitle
+	aStream << '"' << value asString << '" from ' << self stringForSpecTitle


### PR DESCRIPTION
In Pharo 8
SmallInteger does not have the method `putOn:`
So this method raises an error
We can add `asString` or create an extension method?

What is the best option for you ?