### PR TITLE
add-project-class-to-baseline

### DIFF
--- a/BaselineOfStateSpecs/BaselineOfStateSpecs.class.st
+++ b/BaselineOfStateSpecs/BaselineOfStateSpecs.class.st
@@ -43,3 +43,10 @@ BaselineOfStateSpecs >> baseline: spec [
 			group: 'GhostSupportTests' with: #('GhostSupport' 'StateSpecs-GhostSupport-Tests')
 	]
 ]
+
+{ #category : #accessing }
+BaselineOfStateSpecs >> projectClass [
+	^ [ self class environment at: #MetacelloCypressBaselineProject ]
+		on: NotFound
+		do: [ super projectClass ]
+]


### PR DESCRIPTION
Add project class to baseline.

This allows Metacello to better handle the updates of the project.